### PR TITLE
Use `outputName` when calculating the bundle path

### DIFF
--- a/lib/webpack-dependency-plugin.js
+++ b/lib/webpack-dependency-plugin.js
@@ -25,7 +25,7 @@ module.exports = class WebpackDependencyPlugin extends Plugin {
   }
 
   build() {
-    let outputFile = path.join(this.outputPath, '-common-tags-bundle.js');
+    let outputFile = path.join(this.outputPath, `-${this.options.outputName}-bundle.js`);
     if (fs.existsSync(outputFile)) return;
 
     this._writeEntryFile();


### PR DESCRIPTION
This actually didn't have the same issue as ember-apollo-client since the hard-coded path already matched the configured `outputName`, but for consistency... 🙂